### PR TITLE
feat: passing ip address and mask length as an argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tmp/
+
+# binary output
+subnets

--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@ Ensure you have Go installed on your system. You can download and install Go fro
 To install the Subnet Calculator, run the following command:
 
 ```bash
-go install github.com/rochana-atapattu/subnets
+go install github.com/rochana-atapattu/subnets@latest
 ```
 ## Usage
 
-To start the subnet calculator, run:
+```bash
+subnets <IP address> <mask length>
+```
+
+Example
 
 ```bash
-subnets
+subnets 192.168.0.0 24
 ```
 
 Follow the on-screen prompts to enter your network information and perform subnet calculations.

--- a/internal/subnet/util.go
+++ b/internal/subnet/util.go
@@ -3,6 +3,8 @@ package subnet
 import (
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 )
 
 // inetAton converts a dotted IP address string to a uint32.
@@ -26,14 +28,15 @@ func SubnetNetmask(maskLen uint32) uint32 {
 }
 
 func MaskLen(subnetMask uint32) uint32 {
-    // Count the number of leading 1s in the subnetMask.
-    var maskLen uint32 = 0
-    for subnetMask&0x80000000 != 0 {
-        maskLen++
-        subnetMask <<= 1 // Shift left to check the next bit.
-    }
-    return maskLen
+	// Count the number of leading 1s in the subnetMask.
+	var maskLen uint32 = 0
+	for subnetMask&0x80000000 != 0 {
+		maskLen++
+		subnetMask <<= 1 // Shift left to check the next bit.
+	}
+	return maskLen
 }
+
 // networkAddress calculates the network address for a given IP address and subnet mask length.
 func NetworkAddress(ip, maskLen uint32) uint32 {
 	mask := SubnetNetmask(maskLen)
@@ -50,5 +53,17 @@ func SubnetLastAddress(subnet, maskLen uint32) uint32 {
 	return subnet + SubnetAddresses(maskLen) - 1
 }
 
-
-
+// IsValidIPAddress checks if the given string is a valid IPv4 address.
+func IsValidIPAddress(ip string) bool {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		num, err := strconv.Atoi(part)
+		if err != nil || num < 0 || num > 255 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/subnet/util_test.go
+++ b/internal/subnet/util_test.go
@@ -1,0 +1,29 @@
+package subnet
+
+import "testing"
+
+func TestIsValidIPAddress(t *testing.T) {
+	testCases := []struct {
+		ip       string
+		expected bool
+	}{
+		{"192.168.1.1", true},
+		{"255.255.255.255", true},
+		{"0.0.0.0", true},
+		{"256.0.0.0", false},
+		{"192.168.1", false},
+		{"192.168.1.256", false},
+		{"192.168.1.-1", false},
+		{"192.168.1.01", true},
+		{"192.168.1.1.1", false},
+		{"192.168..1", false},
+		{"abc.def.ghi.jkl", false},
+	}
+
+	for _, testCase := range testCases {
+		actual := IsValidIPAddress(testCase.ip)
+		if actual != testCase.expected {
+			t.Errorf("IsValidIPAddress(%q) = %v, expected %v", testCase.ip, actual, testCase.expected)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

* Passing ip address and subnet mask length as an arugment

example:

```bash
subnets 192.168.0.0 24
```

* Readme update